### PR TITLE
Rozwijanie `document` (i innych obiektów z DOM) działa tylko w Chrome

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -201,6 +201,8 @@
                 <p>Do szukania elementów w dokumencie przyda nam się obiekt <code>document</code>.</p>
                 <p class="fragment fade-up note task">Otwórz narzędzia programisty, wpisz w konsoli słowo
                     <code>document</code> i sprawdź, co się stanie.</p>
+                <p class="fragment fade-up note task">Jeśli korzystasz z Chrome, nie zapomnij kliknąć w ►<br/>Jeśli nie
+                    korzystasz z Chrome... to tym razem skorzystaj :)</p>
                 <i class="fragment fade-down fa fa-angle-down"></i>
             </section>
             <section>


### PR DESCRIPTION
#8